### PR TITLE
fix parsing timestamp strings

### DIFF
--- a/src/parseValues.test.ts
+++ b/src/parseValues.test.ts
@@ -24,6 +24,16 @@ test('parse numbers from strings', () => {
   // expect(parseValues(values, FieldType.time)).toStrictEqual([1104537600000, 1136073600000]);
 });
 
+test('parse dates from strings', () => {
+  const timestampValues = ['1630281600000', '1629763200000', '1629849600000'];
+  const isodateValues = ['2021-08-30T00:00:00.000Z', '2021-08-24T00:00:00.000Z', '2021-08-25T00:00:00.000Z'];
+  const mixedValues = ['1630281600000', null, '2021-08-25T00:00:00.000Z'];
+
+  expect(parseValues(timestampValues, FieldType.time)).toStrictEqual([1630281600000, 1629763200000, 1629849600000]);
+  expect(parseValues(isodateValues, FieldType.time)).toStrictEqual([1630281600000, 1629763200000, 1629849600000]);
+  expect(parseValues(mixedValues, FieldType.time)).toStrictEqual([1630281600000, null, 1629849600000]);
+});
+
 test('parse booleans', () => {
   const values = [false, true, false];
 

--- a/src/parseValues.ts
+++ b/src/parseValues.ts
@@ -11,7 +11,7 @@ export const parseValues = (values: any[], type: FieldType): any[] => {
       // epoch in milliseconds.
 
       if (values.filter((_) => _).every((value) => typeof value === 'string')) {
-        return values.map((_) => (_ !== null ? dayjs(_).valueOf() : _));
+        return values.map(parseStringAsTime);
       }
 
       if (values.filter((_) => _).every((value) => typeof value === 'number')) {
@@ -67,4 +67,14 @@ export const parseValues = (values: any[], type: FieldType): any[] => {
     default:
       throw new Error('Unsupported field type');
   }
+};
+
+const parseStringAsTime = (timeString: string | null) => {
+  if (timeString === null) {
+    return timeString;
+  }
+  if (!isNaN(+timeString)) {
+    return dayjs(+timeString).valueOf();
+  }
+  return dayjs(timeString).valueOf();
 };


### PR DESCRIPTION
Fixes #161 

By defautl dayjs parse strings as isoDate. If the string only contain
digits, we can assume it is a timestamp and convert it to number before
giving it to dayjs for parsing.