### PR TITLE
feat: choose http method for datasource test

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -7,11 +7,15 @@ export default class Api {
   cache: any;
   baseUrl: string;
   params: URLSearchParams;
+  method: string;
+  body: string | undefined;
   lastCacheDuration: number | undefined;
 
-  constructor(baseUrl: string, params: string) {
+  constructor(baseUrl: string, params: string, method: string, body?: string) {
     this.baseUrl = baseUrl;
     this.params = new URLSearchParams('?' + params);
+    this.method = method;
+    this.body = body;
     this.cache = new cache.Cache();
   }
 
@@ -50,13 +54,13 @@ export default class Api {
    * Used as a health check.
    */
   async test(): Promise<any> {
-    const data: Record<string, string> = {};
+    const query: Record<string, string> = {};
 
     this.params.forEach((value, key) => {
-      data[key] = value;
+      query[key] = value;
     });
 
-    return this._request('GET', '', data).toPromise();
+    return this._request(this.method, '', query, undefined, this.body).toPromise();
   }
 
   /**

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,6 +1,6 @@
 import {} from '@emotion/core';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
-import { DataSourceHttpSettings, InlineField, InlineFieldRow, Input } from '@grafana/ui';
+import { DataSourceHttpSettings, InlineField, InlineFieldRow, Input, RadioButtonGroup } from '@grafana/ui';
 import React, { ChangeEvent } from 'react';
 import { JsonApiDataSourceOptions } from '../types';
 
@@ -11,12 +11,34 @@ type Props = DataSourcePluginOptionsEditorProps<JsonApiDataSourceOptions>;
  * authentication.
  */
 export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
-  const onParamsChange = (e: ChangeEvent<HTMLInputElement>) => {
+  let isBodyHidden = options.jsonData.method === 'POST' ? false : true;
+  const onParamQueryChange = (e: ChangeEvent<HTMLInputElement>) => {
     onOptionsChange({
       ...options,
       jsonData: {
         ...options.jsonData,
         queryParams: e.currentTarget.value,
+      },
+    });
+  };
+
+  const onParamMethodChange = (e: string) => {
+    isBodyHidden = options.jsonData.method === 'POST' ? false : true;
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        method: e ?? 'GET',
+      },
+    });
+  };
+
+  const onParamBodyChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onOptionsChange({
+      ...options,
+      jsonData: {
+        ...options.jsonData,
+        body: e.currentTarget.value,
       },
     });
   };
@@ -36,11 +58,34 @@ export const ConfigEditor: React.FC<Props> = ({ options, onOptionsChange }) => {
       to set them explicitly.  */}
       <h3 className="page-heading">Misc</h3>
       <InlineFieldRow>
-        <InlineField label="Query string" tooltip="Add a custom query string to your queries.">
+        <InlineField label="Method" tooltip="Choose which http method to use." labelWidth={24}>
+          <RadioButtonGroup
+            value={options.jsonData.method}
+            onChange={onParamMethodChange}
+            options={[
+              { label: 'GET', value: 'GET' },
+              { label: 'POST', value: 'POST' },
+            ]}
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow hidden={isBodyHidden}>
+        <InlineField label="Body" tooltip="Add a body for the request" labelWidth={24}>
+          <Input
+            width={50}
+            value={options.jsonData.body}
+            onChange={onParamBodyChange}
+            spellCheck={false}
+            placeholder="{}"
+          />
+        </InlineField>
+      </InlineFieldRow>
+      <InlineFieldRow>
+        <InlineField label="Query string" tooltip="Add a custom query string to your queries." labelWidth={24}>
           <Input
             width={50}
             value={options.jsonData.queryParams}
-            onChange={onParamsChange}
+            onChange={onParamQueryChange}
             spellCheck={false}
             placeholder="page=1&limit=100"
           />

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -26,7 +26,12 @@ export class JsonDataSource extends DataSourceApi<JsonApiQuery, JsonApiDataSourc
   constructor(instanceSettings: DataSourceInstanceSettings<JsonApiDataSourceOptions>) {
     super(instanceSettings);
 
-    this.api = new API(instanceSettings.url!, instanceSettings.jsonData.queryParams || '');
+    this.api = new API(
+      instanceSettings.url!,
+      instanceSettings.jsonData.queryParams || '',
+      instanceSettings.jsonData.method,
+      instanceSettings.jsonData.body
+    );
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,4 +41,6 @@ export const defaultQuery: Partial<JsonApiQuery> = {
 
 export interface JsonApiDataSourceOptions extends DataSourceJsonData {
   queryParams?: string;
+  method: string;
+  body?: string;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Added option in the datasource config editor for choosing http method
to test the datasource with

**Which issue(s) this PR fixes**:

Issue #279

Fixes #279

**Special notes for your reviewer**:
Hi,
just wanted to say that this is my first experience in participating to the Grafana ecosystem.
I would really love to contribute and this seems to me a good place to start.
I don't really have much experience in js/ts but I'm eager to learn. I'll appreciate any feedback.
Thanks,

gjed
