### PR TITLE
Don't track query requests on dashboard reload

### DIFF
--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,8 +1,12 @@
-import { DataQueryRequest } from '@grafana/data';
+import { CoreApp, DataQueryRequest } from '@grafana/data';
 import { reportInteraction } from '@grafana/runtime';
 import { JsonApiQuery } from 'types';
 
 export const trackRequest = (request: DataQueryRequest<JsonApiQuery>) => {
+  if (request.app === CoreApp.Dashboard || request.app === CoreApp.PanelViewer) {
+    return;
+  }
+
   request.targets.forEach((target) => {
     reportInteraction('grafana_json_query_executed', {
       app: request.app,


### PR DESCRIPTION
currently we track all query requests, this PR excludes requests on dashboard reload which improves performance.