### PR TITLE
updated indirect dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,9 +4028,9 @@ domexception@^4.0.0:
     webidl-conversions "^7.0.0"
 
 dompurify@^2.4.3:
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.7.tgz#277adeb40a2c84be2d42a8bcd45f582bfa4d0cfc"
-  integrity sha512-kxxKlPEDa6Nc5WJi+qRgPbOAbgTpSULL+vI3NUXsZMlkJxTqYI9wg5ZTay2sFrdZRWHPWNi+EdAhcJf81WtoMQ==
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.9.tgz#9ccdd9e1780653156b09de873f5372bc1eaf2c40"
+  integrity sha512-iHtnxYMotKgOTvxIqq677JsKHvCOkAFqj9x8Mek2zdeHW1XjuFKwjpmZeMaXQRQ8AbJZDbcRz/+r1QhwvFtmQg==
 
 dot-prop@^5.2.0:
   version "5.3.0"


### PR DESCRIPTION
we need to update `dompurify`, which is an indirect dependency. here is how i did it:

1. in `package.json` add a `resolution` forcing `dompurify` to `2.4.9`
2. `yarn install` (this updates `yarn.lock`, but not the way we want it)
3. revert the change in `package.json`
4. remove `node_modules` (`rm -rf node_modules`)
5. `yarn install`
6. commit `yarn.lock`
