### PR TITLE
Docs: replace "public" with "shared"

### DIFF
--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -23,6 +23,6 @@ JSON API is an open source data source plugin for Grafana that lets you visualiz
 
 * Since the plugin doesn't keep a record of previous queries, each query needs to contain the complete data set you want to visualize. If you'd like to visualize how the data changes over time, you're probably better off storing the data in a database.
 
-* This plugin doesn't support backend operations such as alerting, recorded queries, public dashboards, enterprise query caching, etc. If you prefer to use one of those options, use the [Grafana Infinity Datasource plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.
+* This plugin doesn't support backend operations such as alerting, recorded queries, shared dashboards, enterprise query caching, etc. If you prefer to use one of those options, use the [Grafana Infinity Datasource plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.
 
 * This plugins doesn't support authentication methods such as OAuth2, digest authentication, jwt authentication. If you prefer to use one of those options, use the [Grafana Infinity Datasource plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.


### PR DESCRIPTION
Replace reference to public dashboard with shared dashboard as part of sharing redesign. Will also be making this change in the docs for the recommended data source plugin.
Related to and should be merged with [grafana/grafana PR 90630](https://github.com/grafana/grafana/pull/90630).