### PR TITLE
docs: update deprecation notice with date and security-update window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JSON API data source for Grafana
 
 > [!CAUTION]
-> This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead
+> This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.
 
 The Grafana JSON Datasource plugin empowers you to seamlessly integrate JSON data into Grafana. JSON is a versatile and widely used data format, and with this plugin, you can easily transform your JSON data into meaningful visualizations within Grafana dashboards.
 

--- a/docs/sources/_index.md
+++ b/docs/sources/_index.md
@@ -14,7 +14,7 @@ weight: 100
 ---
 
 {{< admonition type="warning" >}}
-This plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead
+This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.
 {{< /admonition >}}
 
 JSON API is an open source data source plugin for Grafana that lets you visualize data from any URL that returns JSON, such as REST APIs or static file servers.

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # JSON API data source for Grafana
 
-## (NOTE: this plugin is now in maintenance mode, no new features will be added. We recommend using the [Infinity data source plugin](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead)
+## (NOTE: This plugin is deprecated and will only receive critical security updates. Support will end on Feb 1, 2027. We recommend using the [Infinity data source](https://grafana.com/grafana/plugins/yesoreyeram-infinity-datasource/) instead.)
 
 The Grafana JSON Datasource plugin empowers you to seamlessly integrate JSON data into Grafana. JSON is a versatile and widely used data format, and with this plugin, you can easily transform your JSON data into meaningful visualizations within Grafana dashboards.
 


### PR DESCRIPTION
Mirror the deprecation banner change from grafana-csv-datasource. The banner now states the plugin will be deprecated on February 1, 2027 and until then only receives critical security updates, recommending the Infinity data source instead.