### PR TITLE
Prepare release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.4.1
+
+🐛 Security: bump out-of-SLO react-router to 6.30.4
+
+⚙️ Chore: Update dependencies
+
+📝 Docs: update deprecation notice with date and security-update window
+
 ## 1.4.0
 
 🐛 Replaced deprecated `QueryField` with `Input` component. (plugin crashes with grafana 13 due to react 19 compatibility). With this change, the autocomplete for fields will no longer available.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-json-datasource",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A data source plugin for loading JSON APIs into Grafana",
   "keywords": [
     "grafana",


### PR DESCRIPTION
- Bump version to `1.4.1` in `package.json`
- Update `CHANGELOG.md` with changes since [v1.4.0](https://github.com/grafana/grafana-json-datasource/releases/tag/v1.4.0) (released 2026-07-01)
- Checks: spellcheck pass; merge then run Plugins CI CD per CONTRIBUTING